### PR TITLE
Prepare/npm publish

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -67,7 +67,7 @@ Bilan is an open-source TypeScript SDK + managed analytics platform that helps t
 ### Monorepo Structure
 ```
 packages/
-├── sdk/          # @bilan/sdk - Main TypeScript SDK
+├── sdk/          # @mocksi/bilan-sdk - Main TypeScript SDK
 ├── types/        # Shared TypeScript types
 └── examples/     # Integration examples (nextjs, react, etc.)
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
       options:
         - label: I have searched for existing issues that describe this bug
           required: true
-        - label: I am using the latest version of @bilan/sdk
+        - label: I am using the latest version of @mocksi/bilan-sdk
           required: true
         - label: I have read the documentation
           required: true
@@ -32,7 +32,7 @@ body:
       label: Which package is affected?
       multiple: true
       options:
-        - "@bilan/sdk"
+        - "@mocksi/bilan-sdk"
         - "@bilan/server"
         - "@bilan/dashboard"
         - "Examples"
@@ -111,7 +111,7 @@ body:
       description: Please provide a minimal code sample that reproduces the issue
       render: typescript
       placeholder: |
-        import { init, vote } from '@bilan/sdk'
+        import { init, vote } from '@mocksi/bilan-sdk'
         
         init({
           mode: 'local',

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <div align="center">
 
-[![NPM Version](https://img.shields.io/npm/v/@bilan/sdk?style=flat-square)](https://www.npmjs.com/package/@bilan/sdk)
+[![NPM Version](https://img.shields.io/npm/v/@mocksi/bilan-sdk?style=flat-square)](https://www.npmjs.com/package/@mocksi/bilan-sdk)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue?style=flat-square)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![CI](https://img.shields.io/github/actions/workflow/status/Mocksi/bilan/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/Mocksi/bilan/actions/workflows/ci.yml)
@@ -37,11 +37,11 @@ Bilan is an open source analytics tool that helps you understand how users react
 ### Quick Start
 
 ```bash
-npm install @bilan/sdk
+npm install @mocksi/bilan-sdk
 ```
 
 ```typescript
-import { init, vote, getStats, createUserId, createPromptId } from '@bilan/sdk'
+import { init, vote, getStats, createUserId, createPromptId } from '@mocksi/bilan-sdk'
 
 // Initialize the SDK
 await init({
@@ -61,7 +61,7 @@ console.log(`Trend: ${stats.recentTrend}`) // 'improving' | 'declining' | 'stabl
 ### Advanced Configuration
 
 ```typescript
-import { init, TrendConfig } from '@bilan/sdk'
+import { init, TrendConfig } from '@mocksi/bilan-sdk'
 
 // Custom trend analysis configuration
 const trendConfig: TrendConfig = {
@@ -167,7 +167,7 @@ await init({
 Create separate SDK instances for different contexts:
 
 ```typescript
-import { BilanSDK, createUserId } from '@bilan/sdk'
+import { BilanSDK, createUserId } from '@mocksi/bilan-sdk'
 
 const userSDK = new BilanSDK()
 const adminSDK = new BilanSDK()
@@ -247,14 +247,14 @@ npm run start
 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   @bilan/sdk    │ -> │  Local Storage  │ -> │   Dashboard     │
+│   @mocksi/bilan-sdk    │ -> │  Local Storage  │ -> │   Dashboard     │
 │   (TypeScript)  │    │  or Database    │    │   (Next.js)     │
 └─────────────────┘    └─────────────────┘    └─────────────────┘
 ```
 
 ### What's Included
 
-- **[@bilan/sdk](./packages/sdk)** - TypeScript SDK for tracking user feedback
+- **[@mocksi/bilan-sdk](./packages/sdk)** - TypeScript SDK for tracking user feedback
 - **[Basic Server](./packages/server)** - Self-hostable API server
 - **[Dashboard](./packages/dashboard)** - Web interface for viewing metrics
 - **[Examples](./packages/examples)** - Integration examples (React, Next.js, etc.)
@@ -304,7 +304,7 @@ init({
 The SDK includes an improved trend calculation that uses time weighting and statistical significance. You can configure it with:
 
 ```typescript
-import { init, TrendConfig } from '@bilan/sdk'
+import { init, TrendConfig } from '@mocksi/bilan-sdk'
 
 const customTrendConfig: TrendConfig = {
   sensitivity: 0.2,        // Higher = more sensitive to changes
@@ -438,7 +438,7 @@ curl http://localhost:3001/api/stats?userId=user-123
 
 ```typescript
 import { useEffect, useState } from 'react'
-import { init, vote, getStats } from '@bilan/sdk'
+import { init, vote, getStats } from '@mocksi/bilan-sdk'
 
 export function useBilan(userId: string) {
   const [stats, setStats] = useState(null)
@@ -491,7 +491,7 @@ export default function AIFeedback({ promptId, suggestion }: Props) {
 </template>
 
 <script setup>
-import { init, vote } from '@bilan/sdk'
+import { init, vote } from '@mocksi/bilan-sdk'
 
 const props = defineProps(['promptId', 'suggestion'])
 const { userId } = useAuth()

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,14 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -134,10 +142,6 @@
     },
     "node_modules/@bilan/dashboard": {
       "resolved": "packages/dashboard",
-      "link": true
-    },
-    "node_modules/@bilan/sdk": {
-      "resolved": "packages/sdk",
       "link": true
     },
     "node_modules/@bilan/server": {
@@ -1304,6 +1308,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mocksi/bilan-sdk": {
+      "resolved": "packages/sdk",
+      "link": true
+    },
     "node_modules/@next/env": {
       "version": "15.3.5",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
@@ -2420,13 +2428,6 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -3545,12 +3546,11 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
@@ -5083,13 +5083,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -5888,7 +5881,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@bilan/sdk": "file:../sdk",
+        "@mocksi/bilan-sdk": "file:../sdk",
         "@tailwindcss/postcss": "^4.1.11",
         "next": "^15.3.5",
         "react": "^19.1.0",
@@ -5905,7 +5898,7 @@
       }
     },
     "packages/sdk": {
-      "name": "@bilan/sdk",
+      "name": "@mocksi/bilan-sdk",
       "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
@@ -5924,8 +5917,8 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@bilan/sdk": "file:../sdk",
         "@fastify/cors": "^11.0.1",
+        "@mocksi/bilan-sdk": "file:../sdk",
         "better-sqlite3": "^12.2.0",
         "fastify": "^5.4.0"
       },

--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -35,7 +35,7 @@ const nextConfig = {
   
   // Performance optimizations
   experimental: {
-    optimizePackageImports: ['@bilan/sdk'],
+    optimizePackageImports: ['@mocksi/bilan-sdk'],
   },
   
   // Bundle optimization

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -27,7 +27,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@bilan/sdk": "file:../sdk",
+    "@mocksi/bilan-sdk": "file:../sdk",
     "@tailwindcss/postcss": "^4.1.11",
     "next": "^15.3.5",
     "react": "^19.1.0",

--- a/packages/examples/nextjs/app/page.tsx
+++ b/packages/examples/nextjs/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { init, vote, getStats, BasicStats, createUserId } from '@bilan/sdk'
+import { init, vote, getStats, BasicStats, createUserId } from '@mocksi/bilan-sdk'
 
 export default function Example() {
   const [stats, setStats] = useState<BasicStats | null>(null)

--- a/packages/examples/nextjs/package.json
+++ b/packages/examples/nextjs/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@bilan/sdk": "file:../../sdk",
+    "@mocksi/bilan-sdk": "file:../../sdk",
     "next": "^15.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,50 @@
+# @bilan/sdk
+
+[![NPM Version](https://img.shields.io/npm/v/@bilan/sdk?style=flat-square)](https://www.npmjs.com/package/@bilan/sdk)
+[![Bundle Size](https://img.shields.io/badge/Bundle%20Size-1.7KB%20gzipped-brightgreen?style=flat-square)](https://github.com/Mocksi/bilan/tree/main/packages/sdk)
+[![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue?style=flat-square)](https://www.typescriptlang.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+
+**TypeScript SDK for Bilan trust analytics** - Track user feedback on AI suggestions. Self-hostable, TypeScript-first, <2KB bundle.
+
+## Quick Start
+
+```bash
+npm install @bilan/sdk
+```
+
+```typescript
+import { init, vote, getStats, createUserId, createPromptId } from '@bilan/sdk'
+
+// Initialize the SDK
+await init({
+  mode: 'local',  // or 'server' for self-hosted API
+  userId: createUserId('user-123')
+})
+
+// Track user feedback
+await vote(createPromptId('prompt-abc'), 1, 'Helpful suggestion!')
+
+// Get analytics
+const stats = await getStats()
+console.log(`Trust score: ${(stats.positiveRate * 100).toFixed(1)}%`)
+console.log(`Trend: ${stats.recentTrend}`) // 'improving' | 'declining' | 'stable'
+```
+
+## Features
+
+- **🚀 Lightweight**: 1.7KB gzipped bundle size
+- **🔒 Type Safe**: Full TypeScript support with branded types
+- **🏃‍♂️ Zero Dependencies**: Uses only native web APIs
+- **📱 Universal**: Works in browsers, Node.js, and edge environments
+- **🔧 Configurable**: Advanced trend analysis with customizable parameters
+- **🛡️ Robust**: Comprehensive error handling and graceful degradation
+
+## Documentation
+
+For complete documentation, examples, and self-hosting instructions, visit:
+**[https://github.com/Mocksi/bilan](https://github.com/Mocksi/bilan)**
+
+## License
+
+MIT © [Mocksi](https://github.com/Mocksi) 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
-# @bilan/sdk
+# @mocksi/bilan-sdk
 
-[![NPM Version](https://img.shields.io/npm/v/@bilan/sdk?style=flat-square)](https://www.npmjs.com/package/@bilan/sdk)
+[![NPM Version](https://img.shields.io/npm/v/@mocksi/bilan-sdk?style=flat-square)](https://www.npmjs.com/package/@mocksi/bilan-sdk)
 [![Bundle Size](https://img.shields.io/badge/Bundle%20Size-1.7KB%20gzipped-brightgreen?style=flat-square)](https://github.com/Mocksi/bilan/tree/main/packages/sdk)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue?style=flat-square)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
@@ -10,11 +10,11 @@
 ## Quick Start
 
 ```bash
-npm install @bilan/sdk
+npm install @mocksi/bilan-sdk
 ```
 
 ```typescript
-import { init, vote, getStats, createUserId, createPromptId } from '@bilan/sdk'
+import { init, vote, getStats, createUserId, createPromptId } from '@mocksi/bilan-sdk'
 
 // Initialize the SDK
 await init({

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "directories": {
     "test": "tests"
@@ -24,8 +25,17 @@
     "feedback",
     "typescript"
   ],
-  "author": "",
+  "author": "Mocksi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mocksi/bilan.git",
+    "directory": "packages/sdk"
+  },
+  "homepage": "https://github.com/Mocksi/bilan#readme",
+  "bugs": {
+    "url": "https://github.com/Mocksi/bilan/issues"
+  },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bilan/sdk",
+  "name": "@mocksi/bilan-sdk",
   "version": "0.3.0",
   "description": "TypeScript SDK for Bilan trust analytics",
   "main": "dist/index.js",
@@ -29,7 +29,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Mocksi/bilan.git",
+    "url": "git+https://github.com/Mocksi/bilan.git",
     "directory": "packages/sdk"
   },
   "homepage": "https://github.com/Mocksi/bilan#readme",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,7 +7,7 @@ import { BasicAnalytics } from './analytics/basic-analytics'
  * 
  * @example
  * ```typescript
- * import { init, vote, getStats } from '@bilan/sdk'
+ * import { init, vote, getStats } from '@mocksi/bilan-sdk'
  * 
  * // Initialize the SDK
  * await init({ mode: 'local', userId: 'user-123' })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,7 +32,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@bilan/sdk": "file:../sdk",
+    "@mocksi/bilan-sdk": "file:../sdk",
     "@fastify/cors": "^11.0.1",
     "better-sqlite3": "^12.2.0",
     "fastify": "^5.4.0"

--- a/packages/server/src/database/schema.ts
+++ b/packages/server/src/database/schema.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3'
-import { VoteEvent } from '@bilan/sdk'
+import { VoteEvent } from '@mocksi/bilan-sdk'
 
 export class BilanDatabase {
   private db: Database.Database

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,8 +1,8 @@
 import Fastify, { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import cors from '@fastify/cors'
 import { BilanDatabase } from './database/schema.js'
-import { BasicAnalytics } from '@bilan/sdk'
-import { createPromptId } from '@bilan/sdk'
+import { BasicAnalytics } from '@mocksi/bilan-sdk'
+import { createPromptId } from '@mocksi/bilan-sdk'
 
 export interface ServerConfig {
   port?: number


### PR DESCRIPTION
## Description

This PR migrates the package from `@bilan/sdk` to `@mocksi/bilan-sdk` due to the `@bilan` organization not being available on npm. The package has been successfully published to npm under the Mocksi organization scope.

**Type of Change:**
- [x] 🧹 Code cleanup/refactoring
- [x] 📚 Documentation update
- [x] 🔧 Build/CI changes

## Related Issues

<!-- No specific issues, this was an npm availability issue -->
N/A - Required due to npm organization availability

## Changes Made

<!-- Describe the changes in detail -->

### SDK Changes
- [x] Updated types/interfaces (package name references)
- [x] Updated JSDoc comments with new package name

### Server Changes
- [x] Updated import statements to reference new package name

### Dashboard Changes
- [x] Updated build configuration for new package name

### Other Changes
- Updated all documentation and examples
- Updated GitHub issue templates
- Updated workspace dependencies
- Regenerated package-lock.json

## Testing

<!-- Describe how you tested your changes -->

### Manual Testing
- [x] Tested in browser environment
- [x] Tested in Node.js environment
- [x] Tested with NextJS example
- [x] Verified npm package installation

### Automated Testing
- [x] All existing tests pass
- [x] Test coverage maintained/improved

**Test Results:**
```
> @mocksi/bilan-sdk@0.3.0 test
> vitest

✓ tests/sdk.test.ts (5 tests) 4ms
  ✓ Bilan SDK > should initialize without errors 1ms
  ✓ Bilan SDK > should track votes 1ms
  ✓ Bilan SDK > should calculate prompt-specific stats 0ms
  ✓ Bilan SDK > should detect trends 0ms
  ✓ Bilan SDK > should handle empty state 0ms

Test Files  1 passed (1)
     Tests  5 passed (5)
```

## Bundle Size Impact

### Before
- Bundle size: 5.5 KB
- Gzipped: 1.7 KB

### After  
- Bundle size: 5.5 KB
- Gzipped: 1.7 KB

### Impact
- [x] No size impact

## Breaking Changes

- [x] Breaking changes (documented below)

**Breaking Changes:**
Package name changed from `@bilan/sdk` to `@mocksi/bilan-sdk`. Users need to update their imports:

```typescript
// Before
import { init, vote } from '@bilan/sdk'

// After  
import { init, vote } from '@mocksi/bilan-sdk'
```

## Documentation

- [x] Updated README.md
- [x] Updated API documentation
- [x] Updated examples
- [x] Added JSDoc comments
- [x] Updated CHANGELOG.md (if applicable)

## Performance Impact

- [x] No performance impact

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] No console.log statements left in production code
- [x] TypeScript strict mode compliance

### Testing
- [x] All tests pass locally
- [x] Test coverage is adequate
- [x] Manual testing completed

### Documentation
- [x] Code is self-documenting
- [x] Added JSDoc for public APIs
- [x] Updated relevant documentation
- [x] Added/updated examples if needed

### Security & Privacy
- [x] No secrets or sensitive data in code
- [x] No new security vulnerabilities introduced
- [x] Privacy implications considered

## Additional Context

### Package Publication
- ✅ Package successfully published to npm as `@mocksi/bilan-sdk@0.3.0`
- ✅ Verified installation and import functionality
- ✅ All badges in README now working correctly

### Migration Guide
Users upgrading from any previous version need to:

1. Uninstall the old package: `npm uninstall @bilan/sdk`
2. Install the new package: `npm install @mocksi/bilan-sdk`
3. Update import statements throughout their codebase
4. No API changes - all functionality remains identical

### Future Considerations
- The `@mocksi` organization scope allows for future Mocksi tools to be published under the same namespace
- Maintains consistent branding with the Mocksi company

This change ensures the package is available on npm and properly scoped under the Mocksi organization.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed the package name from @bilan/sdk to @mocksi/bilan-sdk across all code, documentation, and configuration to support npm publishing under the Mocksi organization.

- **Migration**
  - Users must update imports from '@bilan/sdk' to '@mocksi/bilan-sdk' and install the new package. No API changes.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all references, import paths, and documentation to use the new package name `@mocksi/bilan-sdk` instead of `@bilan/sdk`.
  * Added a new README for the SDK with usage instructions, features, and metadata.

* **Chores**
  * Updated package metadata, dependencies, and configuration files to reflect the new package name and repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->