### PR TITLE
Feature/sdk context api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
   "name": "bilan",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bilan",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "devDependencies": {
         "@types/node": "^24.0.12",
-        "tsx": "^4.19.2",
-        "typescript": "^5.6.3"
+        "tsx": "^4.20.3",
+        "typescript": "^5.8.3",
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=14.17.0"
@@ -418,10 +419,6 @@
     },
     "node_modules/@bilan/migration-tools": {
       "resolved": "packages/migration-tools",
-      "link": true
-    },
-    "node_modules/@bilan/server": {
-      "resolved": "packages/server",
       "link": true
     },
     "node_modules/@csstools/color-helpers": {
@@ -1616,6 +1613,10 @@
     },
     "node_modules/@mocksi/bilan-sdk": {
       "resolved": "packages/sdk",
+      "link": true
+    },
+    "node_modules/@mocksi/bilan-server": {
+      "resolved": "packages/server",
       "link": true
     },
     "node_modules/@next/env": {
@@ -6739,7 +6740,7 @@
     },
     "packages/dashboard": {
       "name": "@bilan/dashboard",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@mocksi/bilan-sdk": "file:../sdk",
@@ -6799,7 +6800,7 @@
     },
     "packages/sdk": {
       "name": "@mocksi/bilan-sdk",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",
@@ -6813,8 +6814,8 @@
       }
     },
     "packages/server": {
-      "name": "@bilan/server",
-      "version": "0.3.1",
+      "name": "@mocksi/bilan-server",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "11.0.1",

--- a/packages/sdk/src/error-handling.ts
+++ b/packages/sdk/src/error-handling.ts
@@ -1,5 +1,4 @@
-import { InitConfig, PromptId } from './types'
-import { createPromptId } from './types'
+import { InitConfig } from './types'
 
 export class BilanError extends Error {
   public readonly code: string

--- a/packages/sdk/src/events/turn-tracker.ts
+++ b/packages/sdk/src/events/turn-tracker.ts
@@ -72,12 +72,20 @@ export class TurnTracker {
   private config: InitConfig
   private timeoutMs: number
   private contentProcessor: ContentProcessor
+  private lastGeneratedTurnId: string = ''
 
   constructor(eventTracker: EventTracker, config: InitConfig) {
     this.eventTracker = eventTracker
     this.config = config
     this.timeoutMs = 30000 // 30 seconds default timeout
     this.contentProcessor = new ContentProcessor(new PrivacyController(config.privacyConfig))
+  }
+
+  /**
+   * Get the turnId from the last trackTurn call
+   */
+  getLastTurnId(): string {
+    return this.lastGeneratedTurnId
   }
 
   /**
@@ -93,6 +101,7 @@ export class TurnTracker {
     properties: Record<string, any> = {}
   ): Promise<T> {
     const turnId = generateTurnId()
+    this.lastGeneratedTurnId = turnId  // Store for SDK to access
     const startTime = Date.now()
     
     // Track turn start

--- a/packages/sdk/src/telemetry.ts
+++ b/packages/sdk/src/telemetry.ts
@@ -48,9 +48,9 @@ class TelemetryService {
     return Math.abs(hash).toString(36)
   }
 
-  // Make hashString accessible for promptId hashing
-  public hashPromptId(promptId: string): string {
-    return this.hashString(promptId)
+  // Make hashString accessible for turnId hashing
+  public hashTurnId(turnId: string): string {
+    return this.hashString(turnId)
   }
 
   // Expose queue size for testing
@@ -152,12 +152,12 @@ export function trackEvent(event: Omit<TelemetryEvent, 'timestamp' | 'version' |
   telemetryService.track(event)
 }
 
-export function trackVote(promptId: string, value: 1 | -1, hasComment: boolean): void {
+export function trackVote(turnId: string, value: 1 | -1, hasComment: boolean): void {
   if (!telemetryService) return
   
   trackEvent({
     event: 'vote_recorded',
-    metadata: { value, hasComment, promptIdHash: telemetryService.hashPromptId(promptId) }
+    metadata: { value, hasComment, turnIdHash: telemetryService.hashTurnId(turnId) }
   })
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -92,9 +92,8 @@ export interface UserActionEvent extends Event {
  */
 export interface VoteCastEvent extends Event {
   eventType: 'vote_cast'
-  turn_id: string           // Required - inherits from trackTurn
   properties: {
-    turn_id: string         // Use turn_id instead of promptId
+    turn_id: string         // Required - references the turn being voted on
     value: 1 | -1
     comment?: string
     timestamp: number

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2,7 +2,6 @@
  * Branded types for better type safety and preventing ID confusion.
  */
 export type UserId = string & { __brand: 'UserId' }
-export type PromptId = string & { __brand: 'PromptId' }
 export type ConversationId = string & { __brand: 'ConversationId' }
 export type EventId = string & { __brand: 'EventId' }
 export type TurnId = string & { __brand: 'TurnId' }
@@ -25,7 +24,7 @@ export type EventType =
   | 'custom'
 
 /**
- * Core event interface for flexible analytics
+ * Core event interface for flexible analytics with optional relationship context
  */
 export interface Event {
   eventId: EventId
@@ -33,8 +32,26 @@ export interface Event {
   timestamp: number
   userId: UserId
   properties: Record<string, any>
+  
+  // Optional contextual relationships
+  journey_id?: string
+  conversation_id?: string
+  turn_id?: string
+  turn_sequence?: number
+  
   promptText?: string
   aiResponse?: string
+}
+
+/**
+ * Enhanced context parameter for trackTurn method
+ */
+export interface TurnContext {
+  systemPromptVersion?: string
+  journey_id?: string        // Optional journey context
+  conversation_id?: string   // Optional conversation context  
+  turn_sequence?: number     // Order within conversation
+  [key: string]: any         // Allow additional custom properties
 }
 
 /**
@@ -42,6 +59,7 @@ export interface Event {
  */
 export interface TurnEvent extends Event {
   eventType: 'turn_started' | 'turn_completed' | 'turn_failed'
+  turn_id: string           // Always present for turn events
   properties: {
     turnId: TurnId
     modelUsed?: string
@@ -70,18 +88,19 @@ export interface UserActionEvent extends Event {
 }
 
 /**
- * Event for vote casting (backward compatibility)
+ * Event for vote casting - updated to use turn_id instead of promptId
  */
 export interface VoteCastEvent extends Event {
   eventType: 'vote_cast'
+  turn_id: string           // Required - inherits from trackTurn
   properties: {
-    promptId: PromptId
+    turn_id: string         // Use turn_id instead of promptId
     value: 1 | -1
     comment?: string
-    turnId?: TurnId
-    conversationId?: string
+    timestamp: number
     [key: string]: any
   }
+  // Automatically inherits journey_id, conversation_id if turn had them
 }
 
 /**
@@ -115,8 +134,6 @@ export interface EventQueue {
   flushInterval: number
 }
 
-
-
 /**
  * Interface for custom storage adapters.
  */
@@ -127,13 +144,10 @@ export interface StorageAdapter {
   clear(): Promise<void>
 }
 
-
-
 /**
  * Helper functions to create branded types
  */
 export const createUserId = (id: string): UserId => id as UserId
-export const createPromptId = (id: string): PromptId => id as PromptId
 export const createConversationId = (id: string): ConversationId => id as ConversationId
 
 /**

--- a/packages/sdk/tests/telemetry.test.ts
+++ b/packages/sdk/tests/telemetry.test.ts
@@ -417,8 +417,8 @@ describe('Telemetry', () => {
         const events = body.events
         
         events.forEach((event: any) => {
-          if (event.event === 'vote_recorded' && event.metadata?.promptIdHash) {
-            capturedHashes.push(event.metadata.promptIdHash)
+          if (event.event === 'vote_recorded' && event.metadata?.turnIdHash) {
+            capturedHashes.push(event.metadata.turnIdHash)
           }
         })
         
@@ -437,9 +437,9 @@ describe('Telemetry', () => {
     })
 
     it('should produce consistent hashes for same input', async () => {
-      // Track the same prompt multiple times
-      trackVote('consistent-prompt', 1, true)
-      trackVote('consistent-prompt', -1, false)
+      // Track the same turn multiple times
+      trackVote('consistent-turn', 1, true)
+      trackVote('consistent-turn', -1, false)
       
       // Wait for async operations
       await new Promise(resolve => setTimeout(resolve, 0))
@@ -450,13 +450,13 @@ describe('Telemetry', () => {
     })
 
     it('should produce different hashes for different inputs', async () => {
-      trackVote('prompt-1', 1, true)
-      trackVote('prompt-2', 1, true)
+      trackVote('turn-1', 1, true)
+      trackVote('turn-2', 1, true)
       
       // Wait for async operations
       await new Promise(resolve => setTimeout(resolve, 0))
       
-      // Different prompts should have different hashes
+      // Different turns should have different hashes
       expect(capturedHashes.length).toBe(2)
       expect(capturedHashes[0]).not.toBe(capturedHashes[1])
     })

--- a/packages/sdk/tests/turn-tracker.test.ts
+++ b/packages/sdk/tests/turn-tracker.test.ts
@@ -68,6 +68,20 @@ describe('TurnTracker', () => {
       })
     })
 
+    it('should expose turnId from last trackTurn call', async () => {
+      const mockAiCall = vi.fn().mockResolvedValue('AI response')
+
+      await turnTracker.trackTurn(
+        'Test prompt',
+        mockAiCall,
+        { conversationId: 'conv-123' }
+      )
+
+      const turnId = turnTracker.getLastTurnId()
+      expect(turnId).toMatch(/^turn_\d+_[a-z0-9]+$/)
+      expect(typeof turnId).toBe('string')
+    })
+
     it('should track failed AI turn', async () => {
       const mockError = new Error('API error')
       const mockAiCall = vi.fn().mockRejectedValue(mockError)


### PR DESCRIPTION
## Description

Implements **Section 1.1: Enhanced SDK Context Support** from v0.4.1 implementation guide. This PR replaces the confusing dual-ID system (turn_id + prompt_id) with a unified approach and adds enhanced context tracking capabilities for journey and conversation relationships.

**Type of Change:**
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧹 Code cleanup/refactoring

## Related Issues

Related to v0.4.1 Turn ID Unification implementation
Part of coordinated v0.4.1 release with `feature/flexible-schema`, `feature/analytics-auth`, and `feature/v0.4.1-docs`

## Changes Made

### SDK Changes
- [x] Modified existing APIs  
- [x] Updated types/interfaces
- [x] Code cleanup/refactoring

**Detailed Changes:**
- **Removed** `PromptId` branded type and `createPromptId` function
- **Enhanced** `trackTurn()` to return `{ result: T, turnId: string }` format
- **Added** `TurnContext` interface supporting `journey_id`, `conversation_id`, `turn_sequence`
- **Updated** `vote()` method to accept `turnId` instead of `promptId`
- **Added** optional relationship fields to base `Event` interface
- **Updated** telemetry system to use `turnId` throughout
- **Enhanced** `TurnTracker` to expose generated turnIds

### Server Changes
- [ ] New endpoints
- [ ] Database changes
- [ ] API modifications
- [ ] Bug fixes

### Dashboard Changes
- [ ] New components
- [ ] UI improvements
- [ ] Bug fixes
- [ ] Performance improvements

## Testing

### Manual Testing
- [x] Tested in browser environment
- [x] Tested in Node.js environment
- [ ] Tested with NextJS example
- [x] Tested edge cases

### Automated Testing
- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Updated tests for modified functionality
- [x] Test coverage maintained/improved

**Test Results:**
```
✓ tests/privacy-controls.test.ts (41 tests) 
✓ tests/telemetry.test.ts (25 tests) 
✓ tests/event-queue.test.ts (35 tests)
✓ tests/sdk.test.ts (15 tests) 
✓ src/error-handling.test.ts (21 tests)
✓ tests/turn-tracker.test.ts (17 tests)

Test Files  6 passed (6)
Tests  154 passed (154)
```

## Bundle Size Impact

### Before
- Bundle size: ~5.4KB
- Gzipped: ~1.7KB

### After  
- Bundle size: ~5.4KB
- Gzipped: ~1.7KB

### Impact
- [x] No size impact
- [ ] Size decreased
- [ ] Size increased (justified below)

**Notes:** Removed code (PromptId type/functions) offset by added code (TurnContext interface), resulting in neutral impact.

## Breaking Changes

- [x] Breaking changes (documented below)

**Breaking Changes:**

### 1. trackTurn API Change
```typescript
// Before (v0.4.0)
const result = await trackTurn('prompt', aiFunction, { model: 'gpt-4' })

// After (v0.4.1)
const { result, turnId } = await trackTurn('prompt', aiFunction, { 
  systemPromptVersion: 'v2.1',
  conversation_id: 'conv-123',
  journey_id: 'journey-456'
})
```

### 2. vote Method Change
```typescript
// Before (v0.4.0)
await vote(createPromptId('prompt-123'), 1, 'Great!')

// After (v0.4.1)
await vote(turnId, 1, 'Great!')  // Use turnId from trackTurn
```

### 3. Type System Changes
```typescript
// Removed types
// PromptId, createPromptId() - no longer available

// New types
TurnContext - enhanced context for trackTurn
```

## Documentation

- [ ] Updated README.md *(assigned to feature/v0.4.1-docs branch)*
- [ ] Updated API documentation *(assigned to feature/v0.4.1-docs branch)*
- [ ] Updated examples *(assigned to feature/v0.4.1-docs branch)*
- [x] Added JSDoc comments
- [ ] Updated CHANGELOG.md *(assigned to feature/v0.4.1-docs branch)*

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance decreased (justified below)

**Performance notes:**
- TurnTracker now stores last generated turnId (minimal memory impact)
- Removed unused PromptId type system (slight improvement)
- New TurnContext interface has no runtime overhead

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] No console.log statements left in production code
- [x] TypeScript strict mode compliance

### Testing
- [x] All tests pass locally
- [x] Added tests for new functionality
- [x] Test coverage is adequate
- [x] Manual testing completed

### Documentation
- [x] Code is self-documenting
- [x] Added JSDoc for public APIs
- [ ] Updated relevant documentation *(deferred to docs branch)*
- [ ] Added/updated examples if needed *(deferred to docs branch)*

### Security & Privacy
- [x] No secrets or sensitive data in code
- [x] No new security vulnerabilities introduced
- [x] Privacy implications considered
- [x] Input validation added where needed

## Additional Context

### Migration Guide

**For users upgrading from v0.4.0:**

1. **Update trackTurn calls:**
   ```typescript
   // Change return value destructuring
   const { result, turnId } = await trackTurn(...)
   ```

2. **Update vote calls:**
   ```typescript
   // Store turnId from trackTurn and use in vote
   const { result, turnId } = await trackTurn(...)
   await vote(turnId, 1, 'Good')
   ```

3. **Remove PromptId imports:**
   ```typescript
   // Remove these imports
   import { createPromptId, PromptId } from '@mocksi/bilan-sdk'
   ```

### Future Considerations
- This PR enables turn-vote correlation in upcoming database and API changes
- Sets foundation for enhanced journey and conversation analytics
- Prepared for integration with `feature/flexible-schema` database changes

### Commit History
6 atomic commits following conventional commit format:
- `feat: remove PromptId type and add TurnContext interface`
- `feat: expose turnId from TurnTracker for SDK access`
- `feat: update trackTurn to return turnId and vote to use turnId`
- `fix: remove obsolete PromptId imports from error-handling`
- `test: update tests for new trackTurn and vote API patterns`
- `refactor: replace promptId with turnId in telemetry system`

## Reviewer Checklist

<!-- For reviewers - not filled by PR author -->

- [ ] Code review completed
- [ ] Tests reviewed and adequate
- [ ] Documentation reviewed
- [ ] Breaking changes acceptable
- [ ] Performance impact acceptable
- [ ] Ready to merge
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the dual prompt and turn ID system with a unified turnId, updated the SDK to support enhanced context tracking for journeys and conversations, and changed the vote API to use turnId. This breaks some previous APIs and prepares the SDK for better analytics and turn-vote correlation.

- **New Features**
  - Added TurnContext support to trackTurn, allowing journey_id, conversation_id, and turn_sequence.
  - trackTurn now returns both the result and turnId.
  - vote now accepts turnId instead of promptId.

- **Refactors**
  - Removed PromptId type and related functions.
  - Updated all event and telemetry logic to use turnId.
  - Cleaned up types and tests to match the new API.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Turn tracking now returns both the AI call result and a unique turn ID for each interaction.
  * Added support for richer context when tracking turns, including journey and conversation identifiers.

* **Enhancements**
  * Voting and telemetry are now associated with turn IDs instead of prompt IDs, improving event consistency.
  * Public interfaces and types updated to reflect turn-based tracking and context handling.

* **Bug Fixes**
  * Improved error handling during SDK initialization.

* **Tests**
  * Updated and expanded tests to cover new turn ID features, context handling, and voting changes.
  * Added tests verifying retrieval of the last generated turn ID after tracking turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->